### PR TITLE
CI fixes

### DIFF
--- a/requirements.sh
+++ b/requirements.sh
@@ -2,7 +2,9 @@
 
 set -e
 
-dnf install -y acl atomic docker source-to-image \
+# old s2i breaks tests & functionality
+dnf install -y acl atomic docker \
+  https://kojipkgs.fedoraproject.org//packages/source-to-image/1.1.7/1.fc28/x86_64/source-to-image-1.1.7-1.fc28.x86_64.rpm \
   python3-pyxattr pyxattr \
   python3-docker python2-docker \
   python3-six python2-six \


### PR DESCRIPTION
makefile: better ux, use host's netns
install newest s2i