### PR TITLE
probe: some functions don't have names

### DIFF
--- a/conu/utils/probes.py
+++ b/conu/utils/probes.py
@@ -77,8 +77,12 @@ class Probe(object):
         :param start: Time of function run (used for logging)
         :return:      Return value or Exception
         """
+        try:
+            func_name = self.fnc.__name__
+        except AttributeError:
+            func_name = str(self.fnc)
         logger.debug("Running \"%s\" with parameters: \"%s\":\t%s/%s"
-                     % (self.fnc.__name__, str(self.kwargs), round(time.time() - start), self.timeout))
+                     % (func_name, str(self.kwargs), round(time.time() - start), self.timeout))
         try:
             q.put(self.fnc(**self.kwargs))
         except self.expected_exceptions:


### PR DESCRIPTION
has also commits from `fix-ci` branch

```
Traceback (most recent call last):
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python3.6/multiprocessing/process.py", line 93, in run
    self._target(*self._args, **self._kwargs)
  File "/home/tt/.local/lib/python3.6/site-packages/conu/utils/probes.py", line 81, in _wrapper
    % (self.fnc.__name__, str(self.kwargs), round(time.time() - start), self.timeout))
AttributeError: 'partialmethod' object has no attribute '__name__'
```