### PR TITLE
Add methods for checking mapped ports

### DIFF
--- a/tests/unit/test_docker_container.py
+++ b/tests/unit/test_docker_container.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, unicode_literals
 
-from conu import DockerRunCommand
+from conu import DockerRunCommand, DockerImage, DockerContainer
 
 
 def test_dr_command_class():
@@ -19,3 +19,40 @@ def test_dr_command_class():
     # test whether mutable params are not mutable across instances
     simple.options += ["spy"]
     assert "spy" not in DockerRunCommand().options
+
+
+def test_get_port_mappings():
+    image_name = "registry.fedoraproject.org/fedora"
+    image_tag = "27"
+    image = DockerImage(image_name, image_tag)
+
+    command = DockerRunCommand(additional_opts=["-p", "321:123"])
+
+    try:
+        image.get_metadata()
+    except Exception:
+        image.pull()
+
+    container = DockerContainer.run_via_binary(image, command)
+    try:
+        mappings = container.get_port_mappings(123)
+
+        assert len(mappings) == 1
+        assert mappings == [{"HostIp": '0.0.0.0', "HostPort": '321'}]
+
+        mappings = container.get_port_mappings()
+        assert len(mappings) == 1
+        assert mappings == {'123/tcp': [{'HostIp': '0.0.0.0', 'HostPort': '321'}]}
+    finally:
+        container.stop()
+        container.delete()
+
+    command = DockerRunCommand()
+    container = DockerContainer.run_via_binary(image, command)
+    try:
+        mappings = container.get_port_mappings(123)
+
+        assert not mappings
+    finally:
+        container.stop()
+        container.delete()


### PR DESCRIPTION
Should also fix https://github.com/fedora-modularity/conu/issues/80
Needs to be rebased when https://github.com/fedora-modularity/conu/pull/85 is merged due to container.rm() in https://github.com/dhodovsk/conu/blob/59a0a09559dde285556802eb0d1cd1d256b538a4/tests/unit/test_docker_container.py