### PR TITLE
package conu as an RPM

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+include README.md
+include requirements.txt
+recursive-include tests *
+recursive-include docs *

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,15 @@ test-doc-examples:
 
 check-release:
 	PYTHONPATH=$(CURDIR) pytest -m "release" -s ./tests/release/test_release.py
+
+sdist:
+	./setup.py sdist -d .
+
+rpm: sdist
+	rpmbuild ./*.spec -bb --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}"
+
+srpm: sdist
+	rpmbuild ./*.spec -bs --define "_sourcedir ${PWD}" --define "_specdir ${PWD}" --define "_builddir ${PWD}" --define "_srcrpmdir ${PWD}" --define "_rpmdir ${PWD}"
+
+rpm-in-mock: srpm
+	mock --rebuild -r fedora-27-x86_64 ./*.src.rpm

--- a/conu.spec
+++ b/conu.spec
@@ -1,43 +1,108 @@
-%global framework_name conu
+%global pypi_name conu
 
-Name:           conu
-Version:        0.0.1
+Name:           %{pypi_name}
+Version:        0.1.0
 Release:        1%{?dist}
-Summary:        Container testing library
+Summary:        library which makes it easy to write tests for your containers
 
-License:        GPLv2+
+License:        GPLv3+
 URL:            https://github.com/fedora-modularity/conu
-Source0:        https://codeload.github.com/fedora-modularity/%{name}/tar.gz/%{name}-%{version}.tar.gz
+Source0:        %{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools
-Requires:       docker
-Requires:       coreutils
-Requires:       acl
-Provides:       conu = %{version}-%{release}
+BuildRequires:  python2-sphinx
+
+BuildRequires:  python3-devel
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-sphinx
 
 %description
-Container testing library
+`conu` is a library which makes it easy to write tests for your containers
+and is handy when playing with containers inside your code.
+It defines an API to access and manipulate containers,
+images and provides more, very helpful functions.
+
+
+%package -n     python2-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python2-%{pypi_name}}
+
+Requires:       python2-docker
+Requires:       python2-requests
+Requires:       python2-six
+Requires:       pyxattr
+Requires:       source-to-image
+Requires:       acl
+Requires:       atomic
+Requires:       docker
+Requires:       libselinux-utils
+%description -n python2-%{pypi_name}
+`conu` is a library which makes it easy to write tests for your containers
+and is handy when playing with containers inside your code.
+It defines an API to access and manipulate containers,
+images and provides more, very helpful functions.
+
+
+%package -n     python3-%{pypi_name}
+Summary:        %{summary}
+%{?python_provide:%python_provide python3-%{pypi_name}}
+
+Requires:       python3-docker
+Requires:       python3-requests
+Requires:       python3-six
+Requires:       python3-pyxattr
+Requires:       source-to-image
+Requires:       acl
+Requires:       atomic
+Requires:       docker
+Requires:       libselinux-utils
+%description -n python3-%{pypi_name}
+`conu` is a library which makes it easy to write tests for your containers
+and is handy when playing with containers inside your code.
+It defines an API to access and manipulate containers,
+images and provides more, very helpful functions.
+
+
+%package -n %{pypi_name}-doc
+Summary:        conu documentation
+%description -n %{pypi_name}-doc
+Documentation for conu.
 
 %prep
-%autosetup
+%autosetup -n %{pypi_name}-%{version}
 # Remove bundled egg-info
-rm -rf %{name}.egg-info
+rm -rf %{pypi_name}.egg-info
 
 %build
 %py2_build
+%py3_build
+# generate html docs
+sphinx-build docs/source html
+# remove the sphinx-build leftovers
+rm -rf html/.{doctrees,buildinfo}
 
 %install
+%py3_install
 %py2_install
 
-%files
+%files -n python2-%{pypi_name}
 %license LICENSE
-%{python2_sitelib}/conu/
-%{python2_sitelib}/conu-*.egg-info/
+%doc README.md
+%{python2_sitelib}/%{pypi_name}
+%{python2_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
 
+%files -n python3-%{pypi_name}
+%license LICENSE
+%doc README.md
+%{python3_sitelib}/%{pypi_name}
+%{python3_sitelib}/%{pypi_name}-%{version}-py?.?.egg-info
+
+%files -n %{pypi_name}-doc
+%doc html
+%license LICENSE
 
 %changelog
-* Tue Sep 12 2017 Jan Scotka <jscotka@redhat.com> - 0.0.1-1
-- Initial version
-
+* Wed Dec 06 2017 Tomas Tomecek <ttomecek@redhat.com> - 0.1.0-1
+- Initial package.


### PR DESCRIPTION
* [x] figure out if we want to use tito or not
  * blocker: https://github.com/dgoodwin/tito/issues/308, removing tito for now
* [x] are the names of binary rpms okay? they are: `python2-conu`, `python3-conu` and `conu-doc`