### PR TITLE
Make the docs build against the project path

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@
 #
 # import os
 # import sys
-# sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath('..'))
 import sphinx_rtd_theme
 
 # -- General configuration ------------------------------------------------


### PR DESCRIPTION
When the package is not yet installed, this allow you to build the docs
without explicitly setting the PYTHONPATH.