### PR TITLE
Cleanup methods for containers and images

### DIFF
--- a/conu/backend/docker/backend.py
+++ b/conu/backend/docker/backend.py
@@ -1,10 +1,16 @@
 """
 This is backend for docker engine
 """
+import logging
 
 from conu.apidefs.backend import Backend
 from conu.backend.docker.container import DockerContainer
 from conu.backend.docker.image import DockerImage
+from conu.backend.docker.client import get_client
+from conu.backend.docker.constants import CONU_ARTIFACT_TAG
+
+
+logger = logging.getLogger(__name__)
 
 
 # TODO: use docker-py
@@ -16,3 +22,13 @@ class DockerBackend(Backend):
 
     ContainerClass = DockerContainer
     ImageClass = DockerImage
+
+    @staticmethod
+    def cleanup_containers():
+        client = get_client()
+        conu_containers = client.containers(filters={'label': CONU_ARTIFACT_TAG}, all=True)
+        for c in conu_containers:
+            id = c['Id']
+            logger.debug("Removing container %s created by conu", id)
+            client.stop(id)
+            client.remove_container(id)

--- a/conu/backend/docker/constants.py
+++ b/conu/backend/docker/constants.py
@@ -1,0 +1,2 @@
+# TODO: find alternative
+CONU_ARTIFACT_TAG = 'conu.test_artifact'

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -14,6 +14,7 @@ from conu.backend.docker.client import get_client
 from conu.exceptions import ConuException
 from conu.utils import check_port, run_cmd
 from conu.utils.probes import Probe
+from conu.backend.docker.constants import CONU_ARTIFACT_TAG
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class DockerRunBuilder(object):
 
     def build(self):
         return self.binary + self.global_options + self.command + self.options + \
-            [self.image_name] + self.arguments
+            ["-l", CONU_ARTIFACT_TAG] + [self.image_name] + self.arguments
 
 
 class DockerContainerFS(Filesystem):

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -76,12 +76,23 @@ class DockerImage(Image):
             self._id = self.get_metadata(refresh=False)["Id"]
         return self._id
 
-    def pull(self):
+    def pull(self, always=False):
         """
         pull this image
 
+        :param always: bool, when set to false image is not pulled if
+                        it is already found on system; defaults to false
         :return: None
         """
+        present = True
+        try:
+            self.get_metadata()
+        except Exception:
+            present = False
+
+        if present and not always:
+            return
+
         for o in self.d.pull(repository=self.name, tag=self.tag, stream=True):
             logger.debug(o)
 

--- a/tests/integration/test_backend.py
+++ b/tests/integration/test_backend.py
@@ -1,0 +1,25 @@
+import logging
+
+from .constants import FEDORA_MINIMAL_REPOSITORY, FEDORA_MINIMAL_REPOSITORY_TAG
+
+from conu import DockerImage, DockerRunBuilder, DockerBackend
+from conu.backend.docker.client import get_client
+
+
+def test_cleanup_containers():
+    backend = DockerBackend(logging_level=logging.DEBUG)
+
+    # cleaning up from previous runs
+    backend.cleanup_containers()
+
+    client = get_client()
+    container_sum = len(client.containers(all=True))
+    image = DockerImage(FEDORA_MINIMAL_REPOSITORY, tag=FEDORA_MINIMAL_REPOSITORY_TAG)
+    command = DockerRunBuilder(command=["ls"], additional_opts=["-i", "-t"])
+
+    for i in range(3):
+        image.run_via_binary(command)
+
+    assert container_sum+3 == len(client.containers(all=True))
+    backend.cleanup_containers()
+    assert container_sum == len(client.containers(all=True))

--- a/tests/unit/test_docker_container.py
+++ b/tests/unit/test_docker_container.py
@@ -1,20 +1,21 @@
 from __future__ import print_function, unicode_literals
 
 from conu import DockerRunBuilder, DockerImage
+from conu.backend.docker.constants import CONU_ARTIFACT_TAG
 
 
 def test_dr_command_class():
     simple = DockerRunBuilder()
     simple.image_name = "voodoo"
-    assert ["docker", "container", "run", "voodoo"] == simple.build()
+    assert ["docker", "container", "run", "-l", CONU_ARTIFACT_TAG, "voodoo"] == simple.build()
 
     complex = DockerRunBuilder(additional_opts=["-a", "--foo"])
     complex.image_name = "voodoo"
-    assert ["docker", "container", "run", "-a", "--foo", "voodoo"] == complex.build()
+    assert ["docker", "container", "run", "-a", "--foo", "-l", CONU_ARTIFACT_TAG, "voodoo"] == complex.build()
 
     w_cmd = DockerRunBuilder(command=["x", "y"], additional_opts=["-a", "--foo"])
     w_cmd.image_name = "voodoo"
-    assert ["docker", "container", "run", "-a", "--foo", "voodoo", "x", "y"] == w_cmd.build()
+    assert ["docker", "container", "run", "-a", "--foo", "-l", CONU_ARTIFACT_TAG, "voodoo", "x", "y"] == w_cmd.build()
 
     # test whether mutable params are not mutable across instances
     simple.options += ["spy"]


### PR DESCRIPTION
This PR implements following functionality:
 - Label containers created with conu - in run_via_binary - should be also invoked in implementation of run_via_api
 - Tag images pulled by conu - comes along with presence check of images before pulling
 - when Prune is run, all containers with conu label and images with conu tag are removed
  