### PR TITLE
document implementation status of methods

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -v
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = conu
 SOURCEDIR     = source
@@ -18,3 +18,4 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+

--- a/docs/api_status/__init__.py
+++ b/docs/api_status/__init__.py
@@ -1,0 +1,71 @@
+"""
+This is a sphinx extension which watches autodoc events and extends docstrings with info
+about implementation status of methods
+"""
+
+import inspect
+
+from six import text_type as t
+from sphinx.util import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_method_names(kls):
+    return set([x[0]
+                for x in inspect.getmembers(kls, predicate=inspect.ismethod)
+                if not x[0].startswith("_")])
+
+
+def prepare_lines(txt):
+    """ Let's put some preface first -- the newline is required b/c of reST """
+    return [
+        t(txt),
+        t("")
+    ]
+
+
+def process_methods(txt, kls, methods, lines, short=True):
+    lines += prepare_lines(txt)
+    for method_name in methods:
+        # :class:`conu.apidefs.backend.Backend` class.
+        if short:
+            lines.append(t(" * :meth:`%s.%s`" % (kls.__name__,  method_name)))
+        else:
+            lines.append(t(" * :meth:`%s.%s.%s`" % (kls.__module__, kls.__name__,  method_name)))
+    lines.append(t(""))  # sphinx needs this
+
+
+def process_autodoc(app, what, name, obj, options, lines):
+    if not inspect.isclass(obj):
+        return
+    if obj.__module__.startswith("conu.apidefs."):
+        return
+    for parent_class in inspect.getmro(obj):
+        if parent_class.__module__.startswith("conu.apidefs."):
+            break
+    else:
+        return  # not found
+    these_method_names = get_method_names(obj)
+    parent_method_names = get_method_names(parent_class)
+    extra = these_method_names.difference(parent_method_names)
+    if extra:
+        process_methods("These methods are specific to this backend:", obj, extra, lines)
+    missing = []
+    # we need to check for missing by looking where the method definition lives
+    for method in inspect.getmembers(obj, predicate=inspect.ismethod):
+        method_name, method_obj = method
+        f = inspect.getfile(method_obj)
+        method_code = inspect.getsource(method_obj)
+        if "apidefs" in f and 'NotImplementedError' in method_code:
+            missing.append(method_name)
+    if missing:
+        process_methods("These generic methods are not implemented in this backend:",
+                        parent_class, missing, lines, short=False)
+
+
+def setup(app):
+    app.connect('autodoc-process-docstring', process_autodoc)
+
+    return {'version': '0.1'}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,8 +17,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
+
+import os
+import sys
+
 sys.path.insert(0, os.path.abspath('..'))
 import sphinx_rtd_theme
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,8 +33,11 @@ import sphinx_rtd_theme
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-    'sphinx.ext.coverage']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'api_status'
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Let's merge #122 first.

This patch appends status of implementation of class' methods. This information is recorded in class' docstring; e.g.:

```
These methods are specific to this backend:

 * `get_port_mappings`
 * `wait_for_port`
 * `inspect`
```