### PR TITLE
Fix broken building in Fedora

### DIFF
--- a/conu.spec
+++ b/conu.spec
@@ -8,13 +8,16 @@
 
 Name:           %{pypi_name}
 Version:        0.2.0
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        library which makes it easy to write tests for your containers
 
 License:        GPLv3+
 URL:            https://github.com/fedora-modularity/conu
 Source0:        https://files.pythonhosted.org/packages/source/c/%{pypi_name}/%{pypi_name}-%{version}.tar.gz
 BuildArch:      noarch
+# exclude ppc64 because there is no docker package
+# https://bugzilla.redhat.com/show_bug.cgi?id=1547049
+ExcludeArch:    ppc64
 
 BuildRequires:  python2-devel
 BuildRequires:  python2-setuptools


### PR DESCRIPTION
I'm going to fix this in Fedora too, but I want upstream spec file to be the same, so I don't create some kind of mess. I don't think this warrants even a minor release, so I'm just gonna  bump up release number and keep version the same.

All this does is exclude `ppc64` architecture because of broken dependencies. You can refer to bugzilla link for more details. 