### PR TITLE
`run_via_binary` accept command as a list of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,14 +107,14 @@ def run_container(backend, local_dir):
     image = backend.ImageClass(image_name, tag=image_tag)
 
     # helper class to create `docker run ...` -- we want test the same experience as our users
-    b = DockerRunBuilder(
-        # the command to run in a container
-        command=["python3", "-m", "http.server", "--bind", "0.0.0.0", "%d" % port],
-        # additional options passed to `run` command
-        additional_opts=["-v", "%s:/webroot" % local_dir, "-w", "/webroot"]
-    )
+
+    # the command to run in a container
+    command=["python3", "-m", "http.server", "--bind", "0.0.0.0", "%d" % port],
+    # additional options passed to `run` command
+    additional_opts=["-v", "%s:/webroot" % local_dir, "-w", "/webroot"]
+
     # let's run the container (in the background)
-    container = image.run_via_binary(run_command_instance=b)
+    container = image.run_via_binary(command=command, additional_opts=additional_opts)
     return container
 
 

--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -327,8 +327,8 @@ class DockerContainer(Container):
         Let's look at an example::
 
             image = conu.DockerImage("fedora", tag="27")
-            command = conu.DockerRunBuilder(["bash", "-c", "for x in `seq 1 5`; do echo $x; sleep 1; done"])
-            container = image.run_via_binary(command)
+            command = ["bash", "-c", "for x in `seq 1 5`; do echo $x; sleep 1; done"]
+            container = image.run_via_binary(command=command)
             for line in container.logs(follow=True):
                 print(line)
 

--- a/docs/source/asciinema.rst
+++ b/docs/source/asciinema.rst
@@ -44,4 +44,3 @@ Scenario:
 
     with container.mount() as fs:
         assert fs.file_is_present('/etc/nginx/nginx.conf')
-

--- a/docs/source/examples/check_env.py
+++ b/docs/source/examples/check_env.py
@@ -21,9 +21,9 @@ from conu import DockerBackend, DockerRunBuilder
 
 with DockerBackend() as backend:
     image = backend.ImageClass('fedora')
-    cmd = DockerRunBuilder(additional_opts=['-i', '-e', 'KEY=space'])
+    additional_opts = ['-i', '-e', 'KEY=space']
 
-    cont = image.run_via_binary_in_foreground(cmd, popen_params={"stdin": subprocess.PIPE})
+    cont = image.run_via_binary_in_foreground(additional_opts=additional_opts, popen_params={"stdin": subprocess.PIPE})
     try:
         assert cont.is_running()
         assert cont.logs_unicode() == ""

--- a/docs/source/examples/check_port.py
+++ b/docs/source/examples/check_port.py
@@ -18,8 +18,8 @@ from conu import DockerBackend, DockerRunBuilder
 
 with DockerBackend() as backend:
     image = backend.ImageClass('centos/httpd-24-centos7')
-    command = DockerRunBuilder(additional_opts=["-p", "8080:8080"])
-    container = image.run_via_binary(command)
+    additional_opts = ["-p", "8080:8080"]
+    container = image.run_via_binary(additional_opts=additional_opts)
     container.wait_for_port(port=8080, timeout=-1)
 
     container.stop()

--- a/docs/source/examples/client-server-request.py
+++ b/docs/source/examples/client-server-request.py
@@ -29,8 +29,8 @@ with DockerBackend(logging_level=logging.DEBUG) as backend:
     image = backend.ImageClass('centos/postgresql-96-centos7')
 
     # create server
-    cmd = DockerRunBuilder(additional_opts=environment)
-    dbcont = image.run_via_binary(cmd)
+    additional_opts = environment
+    dbcont = image.run_via_binary(additional_opts=additional_opts)
 
     # wait for server port to be ready
     dbcont.wait_for_port(5432)

--- a/docs/source/examples/readme_webserver.py
+++ b/docs/source/examples/readme_webserver.py
@@ -31,14 +31,10 @@ with DockerBackend(logging_level=logging.DEBUG) as backend:
     # the image will be pulled if it's not present
     image = backend.ImageClass(image_name, tag=image_tag)
 
-    # helper class to create `docker run ...` command -- we want to test the same
-    # experience as our users
-    b = DockerRunBuilder(
-        # the command to run in a container
-        command=["python3", "-m", "http.server", "--bind", "0.0.0.0", "%d" % port],
-    )
+    # the command to run in a container
+    command = ["python3", "-m", "http.server", "--bind", "0.0.0.0", "%d" % port]
     # let's run the container (in the background)
-    container = image.run_via_binary(run_command_instance=b)
+    container = image.run_via_binary(command=command)
     try:
         # we need to wait for the webserver to start serving
         container.wait_for_port(port)

--- a/docs/source/examples/run_image.py
+++ b/docs/source/examples/run_image.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+
 from conu import DockerBackend
 from conu.helpers import get_container_output
 

--- a/docs/source/examples/webserver.py
+++ b/docs/source/examples/webserver.py
@@ -41,15 +41,13 @@ def run_container(backend, local_dir):
     # the image will be pulled if it's not present locally (default behavior)
     image = backend.ImageClass(image_name, tag=image_tag)
 
-    # helper class to create `docker run ...` -- we want test the same experience as our users
-    b = DockerRunBuilder(
-        # the command to run in a container
-        command=["python3", "-m", "http.server", "--bind", "0.0.0.0", "%d" % port],
-        # additional options passed to `run` command
-        additional_opts=["-v", "%s:/webroot" % local_dir, "-w", "/webroot"]
-    )
+    # the command to run in a container
+    command = ["python3", "-m", "http.server", "--bind", "0.0.0.0", "%d" % port]
+    # additional options passed to `run` command
+    additional_opts = ["-v", "%s:/webroot" % local_dir, "-w", "/webroot"]
+
     # let's run the container (in the background)
-    container = image.run_via_binary(run_command_instance=b)
+    container = image.run_via_binary(command=command, additional_opts=additional_opts)
     return container
 
 

--- a/tests/integration/test_backend.py
+++ b/tests/integration/test_backend.py
@@ -18,7 +18,7 @@ import os
 
 from ..constants import FEDORA_MINIMAL_REPOSITORY, FEDORA_MINIMAL_REPOSITORY_TAG
 
-from conu import DockerImage, DockerRunBuilder, DockerBackend
+from conu import DockerImage, DockerBackend
 from conu.backend.docker.client import get_client
 from conu.fixtures import docker_backend
 
@@ -31,10 +31,11 @@ def test_cleanup_containers():
         client = get_client()
         container_sum = len(client.containers(all=True))
         image = DockerImage(FEDORA_MINIMAL_REPOSITORY, tag=FEDORA_MINIMAL_REPOSITORY_TAG)
-        command = DockerRunBuilder(command=["ls"], additional_opts=["-i", "-t"])
+        command = ["ls"]
+        additional_opts = ["-i", "-t"]
 
         for i in range(3):
-            image.run_via_binary(command)
+            image.run_via_binary(command=command, additional_opts=additional_opts)
 
         assert container_sum+3 == len(client.containers(all=True))
         backend.cleanup_containers()

--- a/tests/integration/test_filesystem.py
+++ b/tests/integration/test_filesystem.py
@@ -19,9 +19,8 @@ import pytest
 import six
 
 from conu.backend.docker.backend import DockerBackend
-from conu.backend.docker.container import (
-    DockerRunBuilder, ConuException
-)
+from conu.backend.docker.container import ConuException
+
 from ..constants import FEDORA_MINIMAL_REPOSITORY, FEDORA_MINIMAL_REPOSITORY_TAG
 
 
@@ -36,7 +35,7 @@ class TestDockerContainerFilesystem(object):
         cls.image = cls.backend.ImageClass(
             FEDORA_MINIMAL_REPOSITORY, tag=FEDORA_MINIMAL_REPOSITORY_TAG)
         cls.container = cls.image.run_via_binary(
-            DockerRunBuilder(command=["sleep", "infinity"])
+            command=["sleep", "infinity"]
         )
 
     @classmethod

--- a/tests/integration/test_s2i.py
+++ b/tests/integration/test_s2i.py
@@ -15,7 +15,7 @@
 #
 import os
 
-from conu import DockerRunBuilder, S2IDockerImage
+from conu import S2IDockerImage
 from ..constants import S2I_IMAGE
 
 
@@ -31,7 +31,7 @@ def test_s2i_extending(tmpdir):
     os.chmod(exec_path, 0o755)
     i = S2IDockerImage(S2I_IMAGE)
     ei = i.extend(t, "extended-punchbag")
-    c = ei.run_via_binary(DockerRunBuilder())
+    c = ei.run_via_binary()
     c.wait()
     assert c.logs_unicode() == secret_message + '\n'
 

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -45,9 +45,7 @@ def run_in_container(img_name, img_tag, script):
         i.inspect()
     except Exception:
         i.pull()
-    c = i.run_via_binary(
-        conu.DockerRunBuilder(
-            command=["sleep", "infinity"], additional_opts=["--rm"]))
+    c = i.run_via_binary(command=["sleep", "infinity"], additional_opts=["--rm"])
     try:
         for s in script:
             c.execute(s)

--- a/tests/unit/test_docker_container.py
+++ b/tests/unit/test_docker_container.py
@@ -42,9 +42,9 @@ def test_get_port_mappings():
     image = DockerImage(FEDORA_MINIMAL_REPOSITORY, tag=FEDORA_MINIMAL_REPOSITORY_TAG)
 
     # the container needs to be running in order to get port mappings
-    command = DockerRunBuilder(additional_opts=["-p", "321:123", "-i"])
+    additional_opts = ["-p", "321:123", "-i"]
 
-    container = image.run_via_binary(command)
+    container = image.run_via_binary(additional_opts=additional_opts)
     try:
         mappings = container.get_port_mappings(123)
 
@@ -57,8 +57,7 @@ def test_get_port_mappings():
     finally:
         container.delete(force=True)
 
-    command = DockerRunBuilder()
-    container = image.run_via_binary(command)
+    container = image.run_via_binary()
     try:
         mappings = container.get_port_mappings(123)
 


### PR DESCRIPTION
This PR changes the `.run_via_binary` to accept `command` and `additional_opts` as a list of strings. See #143. 

I will be glad for the reviews and comments.

This PR is WIP, after changes in code will be approved the docs and README needs to be updated also.
