### PR TITLE
Image cleanup policy upgrade

### DIFF
--- a/conu/apidefs/image.py
+++ b/conu/apidefs/image.py
@@ -19,8 +19,6 @@ Abstract definition for an Image
 """
 from __future__ import print_function, unicode_literals
 
-import enum
-
 
 class Image(object):
     """
@@ -163,25 +161,6 @@ class Image(object):
         :return: instance of Container
         """
         raise NotImplementedError("create_container method is not implemented")
-
-
-class ImageCleanupPolicy(enum.Enum):
-    """
-    This Enum defines the policy for cleanup.
-
-    * NOTHING - clean nothing when container exits
-    * EVERYTHING - clean everything when container exits (containers, volumes, images, temporary directories)
-    * CONTAINERS - remove containers
-    * VOLUMES - remove all volumes
-    * IMAGES - remove the image
-    * TMP_DIRS - remove temporary directories
-    """
-    NOTHING = 0
-    EVERYTHING = 1
-    CONTAINERS = 2
-    VOLUMES = 3
-    IMAGES = 4
-    TMP_DIRS = 5
 
 
 class S2Image:

--- a/conu/apidefs/image.py
+++ b/conu/apidefs/image.py
@@ -19,6 +19,8 @@ Abstract definition for an Image
 """
 from __future__ import print_function, unicode_literals
 
+import enum
+
 
 class Image(object):
     """
@@ -161,6 +163,26 @@ class Image(object):
         :return: instance of Container
         """
         raise NotImplementedError("create_container method is not implemented")
+
+
+class ImageCleanupPolicy(enum.Enum):
+    """
+    This Enum defines the policy for cleanup.
+
+    * NOTHING - clean nothing when container exits
+    * EVERYTHING - clean everything when container exits (containers, volumes, images, temporary directories)
+    * CONTAINERS - remove containers
+    * VOLUMES - remove all volumes
+    * IMAGES - remove the image
+    * TMP_DIRS - remove temporary directories
+    """
+    NOTHING = 0
+    EVERYTHING = 1
+    CONTAINERS = 2
+    VOLUMES = 3
+    IMAGES = 4
+    TMP_DIRS = 5
+
 
 class S2Image:
     """

--- a/conu/backend/docker/backend.py
+++ b/conu/backend/docker/backend.py
@@ -38,8 +38,7 @@ class DockerBackend(Backend):
     ContainerClass = DockerContainer
     ImageClass = DockerImage
 
-    @staticmethod
-    def cleanup_containers():
+    def cleanup_containers(self):
         client = get_client()
         conu_containers = client.containers(filters={'label': CONU_ARTIFACT_TAG}, all=True)
         for c in conu_containers:
@@ -48,7 +47,10 @@ class DockerBackend(Backend):
             client.stop(id)
             client.remove_container(id)
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        super(DockerBackend, self).__exit__(exc_type, exc_val, exc_tb)
-        if self.cleanup:
-            DockerBackend.cleanup_containers()
+    def cleanup_volumes(self):
+        # TODO implement cleaning of docker volumes
+        pass
+
+    def cleanup_images(self):
+        # TODO implement cleaning of docker images
+        pass

--- a/tests/integration/test_backend.py
+++ b/tests/integration/test_backend.py
@@ -19,12 +19,13 @@ import os
 from ..constants import FEDORA_MINIMAL_REPOSITORY, FEDORA_MINIMAL_REPOSITORY_TAG
 
 from conu import DockerImage, DockerBackend
+from conu.apidefs.image import ImageCleanupPolicy
 from conu.backend.docker.client import get_client
 from conu.fixtures import docker_backend
 
 
 def test_cleanup_containers():
-    with DockerBackend(logging_level=logging.DEBUG, cleanup=True) as backend:
+    with DockerBackend(logging_level=logging.DEBUG, cleanup=[ImageCleanupPolicy.CONTAINERS]) as backend:
         # cleaning up from previous runs
         backend.cleanup_containers()
 
@@ -43,7 +44,7 @@ def test_cleanup_containers():
 
 
 def test_standard_cleanup_tmpdir():
-    with DockerBackend() as backend:
+    with DockerBackend(cleanup=[ImageCleanupPolicy.TMP_DIRS]) as backend:
         t = backend.tmpdir
         assert os.path.isdir(t)
     assert not os.path.isdir(t)
@@ -64,7 +65,7 @@ def test_non_cm_backend_tmpdir():
     b_tmp = get_backend_tmpdir()
 
     # test reinitialization
-    with DockerBackend(logging_level=logging.DEBUG) as b:
+    with DockerBackend(logging_level=logging.DEBUG, cleanup=[ImageCleanupPolicy.TMP_DIRS]) as b:
         t = b.tmpdir
         assert os.path.isdir(t)
         assert b_tmp == t
@@ -74,4 +75,3 @@ def test_non_cm_backend_tmpdir():
 
 def test_backend_fixture(docker_backend):
     assert isinstance(docker_backend, DockerBackend)
-    

--- a/tests/integration/test_backend.py
+++ b/tests/integration/test_backend.py
@@ -19,13 +19,13 @@ import os
 from ..constants import FEDORA_MINIMAL_REPOSITORY, FEDORA_MINIMAL_REPOSITORY_TAG
 
 from conu import DockerImage, DockerBackend
-from conu.apidefs.image import ImageCleanupPolicy
+from conu.apidefs.backend import CleanupPolicy
 from conu.backend.docker.client import get_client
 from conu.fixtures import docker_backend
 
 
 def test_cleanup_containers():
-    with DockerBackend(logging_level=logging.DEBUG, cleanup=[ImageCleanupPolicy.CONTAINERS]) as backend:
+    with DockerBackend(logging_level=logging.DEBUG, cleanup=[CleanupPolicy.CONTAINERS]) as backend:
         # cleaning up from previous runs
         backend.cleanup_containers()
 
@@ -44,7 +44,7 @@ def test_cleanup_containers():
 
 
 def test_standard_cleanup_tmpdir():
-    with DockerBackend(cleanup=[ImageCleanupPolicy.TMP_DIRS]) as backend:
+    with DockerBackend(cleanup=[CleanupPolicy.TMP_DIRS]) as backend:
         t = backend.tmpdir
         assert os.path.isdir(t)
     assert not os.path.isdir(t)
@@ -65,7 +65,7 @@ def test_non_cm_backend_tmpdir():
     b_tmp = get_backend_tmpdir()
 
     # test reinitialization
-    with DockerBackend(logging_level=logging.DEBUG, cleanup=[ImageCleanupPolicy.TMP_DIRS]) as b:
+    with DockerBackend(logging_level=logging.DEBUG, cleanup=[CleanupPolicy.TMP_DIRS]) as b:
         t = b.tmpdir
         assert os.path.isdir(t)
         assert b_tmp == t


### PR DESCRIPTION
Fix #162 and #163

- cleanup methods are now part of the stable API
- cleanup parameter now accepts list of `CleanupPolicy` enum values

I would be glad for the review and feedback.


