### PR TITLE
installation.rst update

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -13,7 +13,6 @@ At the moment we only support Fedora:
     dnf copr enable ttomecek/conu
     dnf install python{2,3}-conu conu-doc
 
-It's not possible to install conu on CentOS right now due to `these dependency issues <https://github.com/fedora-modularity/conu/issues/106>`_.
 
 
 From PyPI


### PR DESCRIPTION
[Problems with CentOS](https://github.com/fedora-modularity/conu/issues/106) were fixed on #130  and Conu works on CentOS since [release 0.2.0](https://github.com/fedora-modularity/conu/releases/tag/0.2.0) .