### PR TITLE
Pass 'universal_newlines=True' to subprocess.check_output() to decode output from utf-8

### DIFF
--- a/conu/utils/__init__.py
+++ b/conu/utils/__init__.py
@@ -122,7 +122,10 @@ def run_cmd(cmd, return_output=False, ignore_status=False, **kwargs):
     logger.debug('command: "%s"' % ' '.join(cmd))
     try:
         if return_output:
-            return subprocess.check_output(cmd, stderr=subprocess.STDOUT, **kwargs).decode("utf-8")
+            return subprocess.check_output(cmd,
+                                           stderr=subprocess.STDOUT,
+                                           universal_newlines=True,
+                                           **kwargs)
         else:
             subprocess.check_call(cmd, **kwargs)
     except subprocess.CalledProcessError as cpe:
@@ -250,7 +253,9 @@ def check_docker_command_works():
               is thrown
     """
     try:
-        out = subprocess.check_output(["docker", "version"], stderr=subprocess.STDOUT)
+        out = subprocess.check_output(["docker", "version"],
+                                      stderr=subprocess.STDOUT,
+                                      universal_newlines=True)
     except OSError:
         logger.info("docker binary is not available")
         raise CommandDoesNotExistException(


### PR DESCRIPTION
Playing with examples I've spotted the 'docker version' output is bytes:

```
15:36:21.602 __init__.py       INFO   docker environment info: b'Client:\n Version:  ...'
```

Passing `universal_newlines=True` to the [subprocess.check_output()](https://docs.python.org/3/library/subprocess.html#subprocess.check_output) has the side-effect of decoding the output.