### PR TITLE
Move atomic output to debug

### DIFF
--- a/conu/backend/docker/container.py
+++ b/conu/backend/docker/container.py
@@ -81,7 +81,8 @@ class DockerContainerFS(Filesystem):
     def __enter__(self):
         cmd = ["atomic", "mount", self.container.get_id(), self.mount_point]
         logger.debug(cmd)
-        run_cmd(cmd)
+        output = run_cmd(cmd, return_output=True)
+        logger.debug(output)
         return super(DockerContainerFS, self).__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/conu/backend/docker/image.py
+++ b/conu/backend/docker/image.py
@@ -58,7 +58,8 @@ class DockerImageFS(Filesystem):
 
     def __enter__(self):
         # FIXME: I'm not sure about this, is doing docker save/export better?
-        run_cmd(["atomic", "mount", self.image.get_full_name(), self.mount_point])
+        output = run_cmd(["atomic", "mount", self.image.get_full_name(), self.mount_point], return_output=True)
+        logger.debug(output)
         return super(DockerImageFS, self).__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):


### PR DESCRIPTION
Do not show atomic logs in stdout/stderr, but save it to the debug log.