### PR TITLE
Add configuration for release-bot

### DIFF
--- a/release-conf.yaml
+++ b/release-conf.yaml
@@ -1,0 +1,10 @@
+# list of major python versions that release-bot will build separate wheels for
+python_versions:
+  - 3
+  - 2
+# whether to release on fedora
+fedora: true
+# list of fedora branches bot should release on. Master is always implied
+fedora_branches:
+  - f28
+  - f27


### PR DESCRIPTION
to be able to release on PyPi & Fedora (no Bodhi support yet)

I guess we also need to add https://src.fedoraproject.org/user/usercont commit rights to https://src.fedoraproject.org/rpms/conu don't we ?
(you can add jpopelka too BTW)