### PR TITLE
add machinectl service reset and renamed run -> run_via_binary, to be compatible with API

### DIFF
--- a/conu/backend/nspawn/container.py
+++ b/conu/backend/nspawn/container.py
@@ -59,6 +59,16 @@ class NspawnContainer(Container):
         self.start_action = start_action
 
     @staticmethod
+    def machined_restart():
+        """
+        Workaround for systemd when machined is blocked on D-bus
+
+        :return: int: return code
+        """
+        logger.debug("restart systemd-machined")
+        return run_cmd("systemctl restart systemd-machined", ignore_status=True)
+
+    @staticmethod
     def system_requirements():
         """
         Check if all necessary packages are installed on system

--- a/tests/integration/test_nspawn_backend.py
+++ b/tests/integration/test_nspawn_backend.py
@@ -105,7 +105,7 @@ class TestNspawnBackend(object):
     def test_container_basic(self):
         im = NspawnImage(repository=image_name, pull_policy=ImagePullPolicy.IF_NOT_PRESENT,
                          location=url)
-        cont = im.run()
+        cont = im.run_via_binary()
         logger.debug(im.get_metadata())
         logger.debug(cont.get_metadata())
         assert cont.is_running()
@@ -120,7 +120,7 @@ class TestNspawnBackend(object):
     def test_container_exit_states(self):
         im = NspawnImage(repository=image_name, pull_policy=ImagePullPolicy.IF_NOT_PRESENT,
                          location=url)
-        cont = im.run()
+        cont = im.run_via_binary()
         try:
             cont.execute(["exit", "1"])
         except subprocess.CalledProcessError:
@@ -144,7 +144,7 @@ class TestNspawnBackend(object):
         filename = "somefile"
         host_fn = os.path.join(dirname, filename)
         run_cmd(["touch", host_fn])
-        cont = im.run(volumes=["{}:/opt".format(dirname)])
+        cont = im.run_via_binary(volumes=["{}:/opt".format(dirname)])
         cont.execute(["ls", os.path.join("/opt", filename)])
         assert os.path.exists(host_fn)
         cont.execute(["rm", "-f", os.path.join("/opt", filename)])

--- a/tests/integration/test_nspawn_backend.py
+++ b/tests/integration/test_nspawn_backend.py
@@ -95,10 +95,12 @@ class TestNspawnBackend(object):
         out = im.run_foreground(
             ["ls", "/etc"],
             stdout=subprocess.PIPE).communicate()
+        logger.info(out)
         assert "os-release" in out[0]
         out = im.run_foreground(
             ["cat", "/etc/os-release"],
             stdout=subprocess.PIPE).communicate()
+        logger.info(out)
         assert "VERSION_ID=27" in out[0]
         im.rmi()
 


### PR DESCRIPTION
 * add machined restart method, it sometimes hangs.
 * renamed ``run`` to ``run_via_binary`` to be api compatible.
 * add sleep after pull-raw to ensure that all file ops finished well.

# TODO
 * need to fix issue with failed starts
